### PR TITLE
Add Power Meter capability

### DIFF
--- a/WeMo Insight Switch.groovy
+++ b/WeMo Insight Switch.groovy
@@ -22,6 +22,7 @@
         capability "Polling"
         capability "Refresh"
         capability "Sensor"
+	capability "Power Meter"
 
         attribute "currentIP", "string"
 


### PR DESCRIPTION
This will allow you to use the insight switch as a Power Meter in e.g. WebCore.